### PR TITLE
Enable spacebar to toggle pong session

### DIFF
--- a/backend/src/pong.ts
+++ b/backend/src/pong.ts
@@ -64,11 +64,16 @@ export const registerPongWs: FastifyPluginAsync = async (
       try {
         const msg = JSON.parse(text) as
           | { type: "join"; room?: string }
-          | { type: "input"; seq: number; up: boolean; down: boolean };
+          | { type: "input"; seq: number; up: boolean; down: boolean }
+          | { type: "command"; command: "togglePause" };
 
         if (msg.type === "input") {
           if (ws === session.left) {
             session.setLeftInput(!!msg.up, !!msg.down);
+          }
+        } else if (msg.type === "command") {
+          if (ws === session.left && msg.command === "togglePause") {
+            session.togglePause();
           }
         }
       } catch {
@@ -85,6 +90,7 @@ export const registerPongWs: FastifyPluginAsync = async (
       if (ws === session.left) {
         session.left = undefined;
         session.setLeftInput(false, false);
+        session.setPaused(true);
       } else {
         session.spectators.delete(ws);
       }
@@ -93,16 +99,16 @@ export const registerPongWs: FastifyPluginAsync = async (
     ws.on("error", (err) => {
       console.error("[wss] error:", err);
     });
+  });
 
-    app.addHook("onClose", (_app, done) => {
-      try {
-        session.stop();
-        wss.clients.forEach((c) => c.close());
-        wss.close();
-      } finally {
-        done();
-      }
-    });
+  app.addHook("onClose", (_app, done) => {
+    try {
+      session.stop();
+      wss.clients.forEach((c) => c.close());
+      wss.close();
+    } finally {
+      done();
+    }
   });
 
   function safeSend(ws: WebSocket, obj: unknown) {

--- a/backend/src/types/pong.ts
+++ b/backend/src/types/pong.ts
@@ -14,7 +14,8 @@ export type RenderState = {
 
 export type ClientMsg =
   | { type: "join"; room?: string }
-  | { type: "input"; seq: number; up: boolean; down: boolean };
+  | { type: "input"; seq: number; up: boolean; down: boolean }
+  | { type: "command"; command: "togglePause" };
 
 export type ServerMsg =
   | { type: "hello"; you?: string }

--- a/frontend/src/pages/PongCanvasPage.ts
+++ b/frontend/src/pages/PongCanvasPage.ts
@@ -15,8 +15,9 @@ export class PongCanvasPage implements Component {
   private statusEl!: HTMLElement;
   private view = new PongCanvasView({ width: 720, height: 420 });
   private client: PongWsClient | null = null;
-  private tracker = new InputTracker((s) =>
-    this.client?.setInput(s.up, s.down),
+  private tracker = new InputTracker(
+    (s) => this.client?.setInput(s.up, s.down),
+    () => this.client?.togglePause(),
   );
 
   mount(container: HTMLElement) {

--- a/frontend/src/pong/InputTracker.ts
+++ b/frontend/src/pong/InputTracker.ts
@@ -3,11 +3,13 @@ export type InputState = { up: boolean; down: boolean };
 export class InputTracker {
   private state: InputState = { up: false, down: false };
   private onChange?: (s: InputState) => void;
+  private onTogglePause?: () => void;
   private keyPush = (e: KeyboardEvent) => this.handleKey(e, true);
   private keyRelease = (e: KeyboardEvent) => this.handleKey(e, false);
 
-  constructor(onChange?: (s: InputState) => void) {
+  constructor(onChange?: (s: InputState) => void, onTogglePause?: () => void) {
     this.onChange = onChange;
+    this.onTogglePause = onTogglePause;
   }
 
   // register eventlistener
@@ -38,6 +40,11 @@ export class InputTracker {
       if (this.state.down !== pressed) {
         this.state.down = pressed;
         changed = true;
+      }
+    } else if (e.code === "Space" || e.key === " ") {
+      e.preventDefault();
+      if (pressed && !e.repeat) {
+        this.onTogglePause?.();
       }
     }
     // pass the current keybord event into onChange method, this parameter is sent to backend api

--- a/frontend/src/pong/PongWsClient.ts
+++ b/frontend/src/pong/PongWsClient.ts
@@ -85,6 +85,14 @@ export class PongWsClient {
     this.want.down = down;
   }
 
+  togglePause() {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    const msg: ClientMsg = { type: "command", command: "togglePause" };
+    try {
+      this.ws.send(JSON.stringify(msg));
+    } catch {}
+  }
+
   private scheduleReconnect() {
     const t = this.backoff;
     this.backoff = Math.min(this.backoff * 1.7, 8000);

--- a/frontend/src/types/pong.ts
+++ b/frontend/src/types/pong.ts
@@ -14,7 +14,8 @@ export type RenderState = {
 
 export type ClientMsg =
   | { type: "join"; room?: string }
-  | { type: "input"; seq: number; up: boolean; down: boolean };
+  | { type: "input"; seq: number; up: boolean; down: boolean }
+  | { type: "command"; command: "togglePause" };
 
 export type ServerMsg =
   | { type: "hello"; you?: string }


### PR DESCRIPTION
## Summary
- add paused state handling in GameSession so the ball stops until space toggles play
- allow the server to receive togglePause commands and pause automatically when the player leaves
- update frontend input tracking and client messaging to send the togglePause command on spacebar presses

## Testing
- npm --prefix backend run build *(fails: tsconfig pairs module "node18" with incompatible moduleResolution "bundler")*
- npm --prefix frontend run build *(fails: frontend TypeScript build reports RequestProps unused in src/api/apiError.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cb605e7160832cb3c42c7d9ab9115a